### PR TITLE
Add Resume download button to hero section

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,9 +31,19 @@ export default function Header({ profile }: HeaderProps) {
               <p className="text-xs text-gray-600 uppercase tracking-wide">Savings</p>
             </div>
           </div>
-          <div className="flex gap-4">
+          <div className="flex flex-wrap gap-4">
             <a href="#contact" className="px-6 py-3 bg-black text-white rounded-lg hover:bg-gray-800 transition font-medium">
               Get in Touch
+            </a>
+            <a 
+              href="/Sumeet_Sahu_Resume.pdf" 
+              download 
+              className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium inline-flex items-center gap-2"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+              </svg>
+              Resume
             </a>
             <a href={profile.socials.linkedin} target="_blank" rel="noopener noreferrer" className="px-6 py-3 border border-gray-300 rounded-lg hover:border-gray-900 transition font-medium">
               LinkedIn


### PR DESCRIPTION
## Summary
Add a Resume download button to the hero section, allowing visitors to download the PDF resume directly from the homepage.

## Changes
- **Added Resume download button** in `Header.tsx`
  - Blue background for visibility
  - Download icon (document with arrow)
  - Compact text: "Resume"
  - Positioned between "Get in Touch" and "LinkedIn" buttons

## Design
- **Color:** Blue (`bg-blue-600`) - stands out from black/outline buttons
- **Icon:** Download/document icon for clear affordance
- **Text:** Short and clear ("Resume")
- **Behavior:** Downloads `Sumeet_Sahu_Resume.pdf` (292KB) instead of opening in browser

## Testing
- ✅ Local dev server tested (http://localhost:5174/)
- ✅ Button renders correctly
- ✅ Download functionality works
- ✅ Responsive layout (wraps on mobile)
- ✅ Hover effects working

## Files Changed
- `src/components/Header.tsx` - Added download button

## Screenshot
Hero section now shows: