### PR TITLE
Consolidate Adobe experience into single card with career progression

### DIFF
--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -182,7 +182,28 @@ export default function Experience({ experiences }: ExperienceProps) {
                     )}
                   </div>
                   <p className="text-lg text-gray-600 mb-3">{exp.role}</p>
-                  <p className="text-gray-700 leading-relaxed mb-4">{exp.summary}</p>
+                  
+                  {/* Hierarchical roles for consolidated experiences */}
+                  {exp.roles && exp.roles.length > 0 ? (
+                    <div className="mb-4">
+                      <p className="text-gray-700 leading-relaxed mb-4">{exp.summary}</p>
+                      <div className="ml-4 border-l-2 border-gray-300 pl-6 space-y-6">
+                        {exp.roles.map((role, roleIndex) => (
+                          <div key={roleIndex} className="relative">
+                            <div className="absolute -left-[26px] w-3 h-3 rounded-full bg-red-400 border-2 border-white"></div>
+                            <div className="mb-2">
+                              <p className="font-semibold text-gray-800">{role.title}</p>
+                              <p className="text-sm text-gray-500">{role.range}</p>
+                            </div>
+                            <p className="text-sm text-gray-700 leading-relaxed">{role.summary}</p>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-gray-700 leading-relaxed mb-4">{exp.summary}</p>
+                  )}
+                  
                   <div className="flex flex-wrap gap-2">
                     {exp.company.includes('Intuit') && (
                       <>
@@ -257,7 +278,21 @@ export default function Experience({ experiences }: ExperienceProps) {
                     )}
                   </div>
                   <p className="text-sm text-gray-500 mb-3">{exp.range}</p>
-                  <p className="text-sm text-gray-700">{exp.role}</p>
+                  <p className="text-sm text-gray-700 mb-2">{exp.role}</p>
+                  
+                  {/* Show role progression for consolidated experiences */}
+                  {exp.roles && exp.roles.length > 0 && (
+                    <div className="mt-3 pt-3 border-t border-gray-200">
+                      <p className="text-xs text-gray-500 mb-2">Career Progression:</p>
+                      <div className="space-y-1">
+                        {exp.roles.map((role, roleIndex) => (
+                          <div key={roleIndex} className="text-xs text-gray-600">
+                            <span className="font-medium">•</span> {role.title} <span className="text-gray-400">({role.range})</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -12,16 +12,22 @@
         "range": "February 2020 — September 2024"
     },
     {
-        "role": "Computer Scientist - II",
+        "role": "Computer Scientist - II (promoted from Computer Scientist)",
         "company": "Adobe India - Noida",
-        "summary": "Directed full lifecycle development of Gyarados, a central asynchronous service platform for Adobe Experience Cloud (CC Home) synchronizing digital assets for millions of users. Designed and deployed highly available, secure core frameworks within multi-cloud containerized environment. Key contributions: dockerization of Windows Workers, architecture of new orchestration layer, and custom autoscaling strategies for asynchronous services optimizing performance and resource efficiency across multiple clouds.",
-        "range": "July 2016 — February 2020"
-    },
-    {
-        "role": "Computer Scientist",
-        "company": "Adobe India - Noida",
-        "summary": "Spearheaded development of PDF Scan Library SDK and PCL Print Engine, delivering high-performance solution for converting scanned documents into authentic Adobe PDFs. Engineered core functionalities including DRM protection, digital timestamping, and image cleanup, ensuring enterprise-grade security and PDF/A compliance. Managed end-to-end integration of features like watermarking and document security, providing customers with robust toolkit for professional-grade document digitization.",
-        "range": "July 2015 — June 2016"
+        "summary": "Progressive career spanning platform architecture and SDK development at Adobe. Led Gyarados platform for Adobe Experience Cloud serving millions; developed PDF Scan SDK with DRM, security, and compliance. Specialized in multi-cloud containerization, orchestration, and enterprise-grade document solutions.",
+        "range": "July 2015 — February 2020",
+        "roles": [
+            {
+                "title": "Computer Scientist - II",
+                "range": "July 2016 — February 2020",
+                "summary": "Directed full lifecycle development of Gyarados, a central asynchronous service platform for Adobe Experience Cloud (CC Home) synchronizing digital assets for millions of users. Designed and deployed highly available, secure core frameworks within multi-cloud containerized environment. Key contributions: dockerization of Windows Workers, architecture of new orchestration layer, and custom autoscaling strategies for asynchronous services optimizing performance and resource efficiency across multiple clouds."
+            },
+            {
+                "title": "Computer Scientist",
+                "range": "July 2015 — June 2016",
+                "summary": "Spearheaded development of PDF Scan Library SDK and PCL Print Engine, delivering high-performance solution for converting scanned documents into authentic Adobe PDFs. Engineered core functionalities including DRM protection, digital timestamping, and image cleanup, ensuring enterprise-grade security and PDF/A compliance. Managed end-to-end integration of features like watermarking and document security, providing customers with robust toolkit for professional-grade document digitization."
+            }
+        ]
     },
     {
         "role": "Software Engineer 2",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,8 +1,15 @@
+export interface Role {
+  title: string;
+  range: string;
+  summary: string;
+}
+
 export interface Experience {
   role: string;
   company: string;
   summary: string;
   range: string;
+  roles?: Role[]; // Optional: for consolidated experiences with career progression
 }
 
 export interface Skill {


### PR DESCRIPTION
## Summary
- Consolidates two separate Adobe India entries into a single card showing clear career progression
- Improves UX by reducing duplicate cards for the same company
- Adds visual timeline in "All Experience" tab with hierarchical role display
- Shows career progression details in "Enterprise" tab

## Changes
- **Data Structure**: Added `Role` interface and optional `roles` array to `Experience` type
- **Experience Data**: Merged Computer Scientist and Computer Scientist - II into one entry with roles timeline
- **All Experience Tab**: Visual timeline with red dot markers and left border showing both roles chronologically
- **Enterprise Tab**: Compact career progression display with role titles and date ranges
- **Maintains backward compatibility**: Experiences without `roles` array render normally

## Visual Improvements
### All Experience Tab
- Hierarchical timeline with visual markers
- Clear separation between roles with dates
- Full summaries for each role preserved

### Enterprise Tab  
- Compact "Career Progression" section
- Shows both roles with date ranges
- Clean, professional appearance

## Testing
- ✅ TypeScript compilation successful
- ✅ No linter errors
- ✅ Manual testing verified in local browser
- ✅ All tabs (Featured, All Experience, Enterprise) working correctly
- ✅ Backward compatible with other experience entries

## Impact
Both "All Experience" and "Enterprise" tabs now show a single Adobe card instead of two separate entries, better representing the career progression at the same company.