### PR TITLE
Resume generator: use achievements and patents from src/data

### DIFF
--- a/resume-generator/generator.js
+++ b/resume-generator/generator.js
@@ -72,22 +72,19 @@ async function main() {
   const experiences = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'experience.json'), 'utf8'));
   const skills = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'skills.json'), 'utf8'));
   const education = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'education.json'), 'utf8'));
+  const achievementsData = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'achievements.json'), 'utf8'));
+  const patentsData = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'patents.json'), 'utf8'));
 
-  // Define key achievements (you can move this to a separate JSON file later if needed)
-  const achievements = [
-    'Pioneered GenAI code generation initiative impacting 8,000+ developers with 50% productivity improvement',
-    'Delivered $600K annual cost savings through Apache Beam migration processing 1.5B daily transactions',
-    'Scaled myPNRstatus startup from zero to 600,000 users as solo founder',
-    'Architected multi-cloud orchestration platform serving millions of Adobe Experience Cloud users'
-  ];
+  // One-line bullets for resume from achievements (description is impact-focused)
+  const achievements = achievementsData.achievements.map((a) => a.description);
 
-  // Patent information (you can move this to a separate JSON file later if needed)
-  const patent = {
-    title: 'Digital Media Environment for Removal of Interference Patterns from Digital Images',
-    number: 'US Patent 10,134,113',
-    date: 'November 20, 2018',
-    assignee: 'Adobe Inc.'
-  };
+  // Patents in template shape: { title, number, date, assignee }
+  const patents = (patentsData.patents || []).map((p) => ({
+    title: p.title,
+    number: p.patentNumber,
+    date: p.issueDate,
+    assignee: p.assignee
+  }));
 
   // Generate resume
   console.log('🔨 Generating resume...');
@@ -98,7 +95,7 @@ async function main() {
     skills,
     education,
     achievements,
-    patent
+    patents
   });
 
   // Write to file

--- a/resume-generator/template.js
+++ b/resume-generator/template.js
@@ -4,7 +4,7 @@
  */
 
 function generateResumeHTML(data) {
-  const { profile, experiences, skills, education, achievements, patent } = data;
+  const { profile, experiences, skills, education, achievements, patents } = data;
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -260,13 +260,14 @@ function generateResumeHTML(data) {
     </div>
 
     <!-- Patents -->
-    ${patent ? `
+    ${patents && patents.length > 0 ? `
     <div class="section">
         <div class="section-title">Patents & Publications</div>
+        ${patents.map(p => `
         <div class="patent-item">
-            <div class="patent-title">${patent.title}</div>
-            <div class="patent-number">${patent.number} • Issued ${patent.date} • ${patent.assignee}</div>
-        </div>
+            <div class="patent-title">${p.title}</div>
+            <div class="patent-number">${p.number} • Issued ${p.date} • ${p.assignee}</div>
+        </div>`).join('\n')}
     </div>` : ''}
 
     <!-- Technical Skills -->


### PR DESCRIPTION
## Summary
Resume generator no longer hardcodes achievements or patent data. It reads from `src/data/achievements.json` and `src/data/patents.json`, so the resume stays in sync with the site and one source of truth.

## Changes
- **generator.js:** Loads `achievements.json` and `patents.json` from `src/data/`. Builds achievement bullets from each item’s `description` and maps patents to `{ title, number, date, assignee }`.
- **template.js:** Uses a `patents` array instead of a single `patent` and renders all entries in the Patents & Publications section.

## Base
Branch is from `feature/auto-resume-pdf`. Consider merging that first, or set base to `master` if you want this as a standalone PR.