### PR TITLE
Compute years of experience from careerStartDate and use {{years}} in profile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { ProfileData } from '../types';
+import { resolveYearsPlaceholder, resolveHeadlineStatValue } from '../utils/profile';
 
 interface HeaderProps {
   profile: ProfileData;
@@ -8,6 +9,7 @@ export default function Header({ profile }: HeaderProps) {
   const nameParts = profile.name.trim().split(/\s+/);
   const firstName = nameParts[0] ?? '';
   const lastName = nameParts.slice(1).join(' ') || '';
+  const summary = resolveYearsPlaceholder(profile.summary, profile.careerStartDate);
 
   return (
     <section className="py-20 px-6 border-b">
@@ -24,13 +26,13 @@ export default function Header({ profile }: HeaderProps) {
             ) : null}
           </h1>
           <p className="text-xl text-gray-600 mb-8 leading-relaxed max-w-2xl">
-            {profile.summary}
+            {summary}
           </p>
           {profile.headlineStats && profile.headlineStats.length > 0 && (
             <div className="flex flex-wrap gap-6 max-w-xl mb-8">
               {profile.headlineStats.map((stat, index) => (
                 <div key={index} className="text-center p-4 bg-gray-50 rounded-lg">
-                  <p className="text-3xl font-semibold mb-1">{stat.value}</p>
+                  <p className="text-3xl font-semibold mb-1">{resolveHeadlineStatValue(stat.value, profile.careerStartDate)}</p>
                   <p className="text-xs text-gray-600 uppercase tracking-wide">{stat.label}</p>
                 </div>
               ))}

--- a/src/data/earlyInitiatives.json
+++ b/src/data/earlyInitiatives.json
@@ -29,7 +29,7 @@
     {
       "name": "ShareTheRide.in",
       "tagline": "Corporate Carpooling Platform",
-      "year": "2010",
+      "year": "2011",
       "description": "This was an intuitive ride-sharing portal designed specifically for daily office commutes, initially launched for employees at CA Technologies (now Broadcom) in Hyderabad. The platform helped users find colleagues or professionals from reputable companies for carpooling or bike-sharing. To solve for safety and trust, the service included a verification system to ensure users were active employees of recognized organizations, focusing on reducing commuting costs and traffic congestion through a secure professional community.",
       "icon": "🚗",
       "status": "Early Stage Initiative",

--- a/src/data/profile.json
+++ b/src/data/profile.json
@@ -4,8 +4,9 @@
   "location": "Bengaluru, India",
   "email": "contactme@sumeetsahu.com",
   "phone": "+91-9963027920",
-  "metaDescription": "Principal Engineer at Intuit with 17+ years building scalable systems. Expert in GenAI-driven development, distributed systems architecture, and engineering efficiency.",
-  "summary": "Principal Engineer at Intuit, NITK alumnus with 17+ years building scalable systems. Expert in GenAI-driven development, distributed systems architecture, and engineering efficiency. Track record of 50% productivity improvements, $600K+ cost savings, and serving millions of users across Intuit, Amazon, Adobe, Microsoft, and startups.",
+  "careerStartDate": "2007-06",
+  "metaDescription": "Principal Engineer at Intuit with {{years}}+ years building scalable systems. Expert in GenAI-driven development, distributed systems architecture, and engineering efficiency.",
+  "summary": "Principal Engineer at Intuit, NITK alumnus with {{years}}+ years building scalable systems. Expert in GenAI-driven development, distributed systems architecture, and engineering efficiency. Track record of 50% productivity improvements, $600K+ cost savings, and serving millions of users across Intuit, Amazon, Adobe, Microsoft, and startups.",
   "profileImage": "/profile.svg",
   "socials": {
     "linkedin": "https://www.linkedin.com/in/sumeetsahu/",
@@ -13,7 +14,7 @@
     "facebook": "https://www.facebook.com/sumeetsahu/"
   },
   "headlineStats": [
-    { "value": "17+", "label": "Years" },
+    { "value": "{{years}}+", "label": "Years" },
     { "value": "8K+", "label": "Developers" },
     { "value": "$600K+", "label": "Savings" }
   ],

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -106,6 +106,8 @@ export interface ProfileData {
   location: string;
   email: string;
   phone: string;
+  /** Career start date (YYYY-MM, e.g. "2007-06"). Used to compute {{years}} in summary, metaDescription, and headlineStats. */
+  careerStartDate?: string;
   summary: string;
   /** Short description for HTML meta and SEO (defaults to summary if omitted) */
   metaDescription?: string;

--- a/src/utils/profile.ts
+++ b/src/utils/profile.ts
@@ -1,0 +1,35 @@
+/**
+ * Years of experience from career start date (YYYY-MM).
+ * Uses month precision; e.g. "2007-06" = June 2007.
+ */
+export function getYearsOfExperience(careerStartDate: string): number {
+  const [y, m] = careerStartDate.split('-').map(Number);
+  if (!y || Number.isNaN(y)) return 0;
+  const start = new Date(y, (m || 1) - 1, 1);
+  const now = new Date();
+  const years = (now.getTime() - start.getTime()) / (365.25 * 24 * 60 * 60 * 1000);
+  return Math.floor(years);
+}
+
+/** Resolves {{years}} placeholder in a string using career start date. */
+export function resolveYearsPlaceholder(
+  text: string,
+  careerStartDate: string | undefined
+): string {
+  if (!careerStartDate || !text.includes('{{years}}')) return text;
+  const years = getYearsOfExperience(careerStartDate);
+  return text.replace(/\{\{years\}\}/g, String(years));
+}
+
+/** Resolves headline stat value; supports "{{years}}+" for experience. */
+export function resolveHeadlineStatValue(
+  value: string,
+  careerStartDate: string | undefined
+): string {
+  if (!careerStartDate) return value;
+  if (value === '{{years}}+' || value.includes('{{years}}')) {
+    const years = getYearsOfExperience(careerStartDate);
+    return value.replace(/\{\{years\}\}/g, String(years));
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary
Years of experience are no longer hardcoded. A single `careerStartDate` in profile (e.g. `"2007-06"` for June 2007) drives the number everywhere via a `{{years}}` placeholder.

## Changes
- **profile.json:** Added `careerStartDate: "2007-06"`. Replaced fixed "17+" with `{{years}}+` in `metaDescription`, `summary`, and the first headline stat.
- **src/utils/profile.ts:** New helpers: `getYearsOfExperience(startDate)`, `resolveYearsPlaceholder()`, `resolveHeadlineStatValue()`.
- **Header.tsx:** Resolves `{{years}}` in summary and headline stat values using profile data.
- **vite.config.ts:** Replaces `{{years}}` in meta description at build time from `careerStartDate`.
- **resume-generator/generator.js:** Resolves `{{years}}` in profile summary (and headline stats) before generating HTML/PDF.
- **types:** Added optional `careerStartDate` to `ProfileData`.
- **earlyInitiatives.json:** Corrected ShareTheRide.in year (2010 → 2011).

## Base
Branch created from `feature/configurable-index-meta`. Set base as needed when opening the PR.