### PR TITLE
Add profile website to resume and match education styling to patents

### DIFF
--- a/resume-generator/template.js
+++ b/resume-generator/template.js
@@ -169,18 +169,14 @@ function generateResumeHTML(data) {
             align-items: baseline;
         }
 
-        .degree {
-            font-size: 10pt;
-            font-weight: 600;
-        }
-
         .school {
             font-size: 10pt;
-            color: #4a4a4a;
-            margin-bottom: 2pt;
+            font-weight: 600;
+            color: #1a1a1a;
+            margin-bottom: 3pt;
         }
 
-        .major {
+        .degree {
             font-size: 9pt;
             color: #666;
         }
@@ -230,7 +226,7 @@ function generateResumeHTML(data) {
             ${profile.location} • 
             <a href="mailto:${profile.email}">${profile.email}</a> • 
             ${profile.phone} • 
-            <a href="${profile.socials.linkedin}">${socialDisplay(profile.socials?.linkedin)}</a> • 
+            ${profile.website ? `<a href="${profile.website.startsWith('http') ? profile.website : 'https://' + profile.website}">${socialDisplay(profile.website)}</a> • ` : ''}<a href="${profile.socials.linkedin}">${socialDisplay(profile.socials?.linkedin)}</a> • 
             <a href="${profile.socials.github}">${socialDisplay(profile.socials?.github)}</a>
         </div>
     </div>

--- a/src/data/profile.json
+++ b/src/data/profile.json
@@ -19,6 +19,7 @@
     { "value": "$600K+", "label": "Savings" }
   ],
   "resumeUrl": "/Sumeet_Sahu_Resume.pdf",
+  "website": "https://www.sumeetsahu.com",
   "contactTitle": "Let's Connect",
   "contactTagline": "Open to consulting, speaking engagements, and interesting opportunities."
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,6 +121,8 @@ export interface ProfileData {
   headlineStats?: HeadlineStat[];
   /** Optional resume download URL or path */
   resumeUrl?: string;
+  /** Optional personal/profile website URL (e.g. https://www.sumeetsahu.com) */
+  website?: string;
   /** Optional contact section title and tagline */
   contactTitle?: string;
   contactTagline?: string;


### PR DESCRIPTION
## Summary
Adds a link to the profile website (www.sumeetsahu.com) in the resume contact line and aligns education section styling with the patents section.

## Changes
- **Profile:** Added optional `website` to `ProfileData` and `profile.json` (`https://www.sumeetsahu.com`). Resume contact line shows a clickable website link when `website` is set.
- **Resume education styling:** School name (e.g. "National Institute of Technology Karnataka") is now dark and bold like patent titles; degree line (e.g. "Bachelor of Technology in Electronics and Communication") is gray and 9pt like patent metadata (US 10,134,113 • Issued ... • Adobe Inc.).

## Base
Branch created from `feature/years-of-experience-from-profile`. Set base as needed when opening the PR.