### PR TITLE
Resume: format contact block in two lines

### DIFF
--- a/resume-generator/template.js
+++ b/resume-generator/template.js
@@ -223,11 +223,9 @@ function generateResumeHTML(data) {
         <div class="name">${profile.name.toUpperCase()}</div>
         <div class="title">${profile.title}</div>
         <div class="contact">
-            ${profile.location} • 
-            <a href="mailto:${profile.email}">${profile.email}</a> • 
-            ${profile.phone} • 
-            ${profile.website ? `<a href="${profile.website.startsWith('http') ? profile.website : 'https://' + profile.website}">${socialDisplay(profile.website)}</a> • ` : ''}<a href="${profile.socials.linkedin}">${socialDisplay(profile.socials?.linkedin)}</a> • 
-            <a href="${profile.socials.github}">${socialDisplay(profile.socials?.github)}</a>
+            <span class="contact-line">${profile.phone} • <a href="mailto:${profile.email}">${profile.email}</a> • ${profile.location}</span>
+            <br>
+            <span class="contact-line">${profile.website ? `<a href="${profile.website.startsWith('http') ? profile.website : 'https://' + profile.website}">${socialDisplay(profile.website)}</a> • ` : ''}<a href="${profile.socials.linkedin}">${socialDisplay(profile.socials?.linkedin)}</a> • <a href="${profile.socials.github}">${socialDisplay(profile.socials?.github)}</a></span>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
Resume header contact is now split into two clear lines instead of one long line that wraps awkwardly.

## Changes
- **Line 1:** Phone • Email • City (e.g. +91-9963027920 • contactme@sumeetsahu.com • Bengaluru, India)
- **Line 2:** Website • LinkedIn • GitHub (e.g. sumeetsahu.com • linkedin.com/in/sumeetsahu • github.com/sumeetsahu)

Implemented in `resume-generator/template.js`; HTML and PDF are regenerated via `npm run generate-resume`.

## Base
Branch created from `feature/resume-website-and-education-styling`. Set base as needed when opening the PR.