### PR TITLE
Add Google Analytics (GA4) with traffic and engagement tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Google Analytics (GA4). Optional.
+# Create a GA4 property at https://analytics.google.com/, then set:
+# VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+# Leave unset for local/dev builds (analytics is disabled when unset).

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/README.md
+++ b/README.md
@@ -217,6 +217,32 @@ npm run build
 # Upload dist/ contents to any static host
 ```
 
+### Google Analytics (optional)
+
+To track traffic and how visitors interact with buttons and links. **Full steps and reference:** [docs/GOOGLE_ANALYTICS.md](docs/GOOGLE_ANALYTICS.md).
+
+1. Create a [GA4 property](https://analytics.google.com/) and copy your **Measurement ID** (e.g. `G-XXXXXXXXXX`).
+2. Add it to your environment:
+   - **Local:** Create a `.env` file in the project root with `VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX`.
+   - **GitHub Actions:** In the repo go to **Settings** → **Secrets and variables** → **Actions**, add a secret `VITE_GA_MEASUREMENT_ID` with your ID, then in the workflow add an `env` block to the build step (see below).
+3. Rebuild and deploy. Analytics is disabled when the variable is unset (e.g. local dev without `.env`).
+
+**Tracked automatically:**
+
+- **Page views** – initial load (and path).
+- **Clicks** – Get in Touch, Resume download, LinkedIn, GitHub, Email, Contact section links, Footer links, Experience tabs (Featured / All / Enterprise), Patents “Google Patents” link.
+
+In GA4 you can see which buttons/links get clicks; if a button gets no events, visitors may be avoiding it or ad-blockers may be blocking the script (you’ll still see traffic from users who don’t block).
+
+**GitHub Actions:** To enable GA on the deployed site, add the secret `VITE_GA_MEASUREMENT_ID` and pass it into the build:
+
+```yaml
+- name: Build
+  run: npm run build
+  env:
+    VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
+```
+
 ### GitHub Pages Setup
 
 **First-time setup:**

--- a/docs/GOOGLE_ANALYTICS.md
+++ b/docs/GOOGLE_ANALYTICS.md
@@ -1,0 +1,157 @@
+# Google Analytics (GA4) Setup & Reference
+
+This document describes how Google Analytics is integrated into the profile site and how to set it up for local development and production. Use it as a reference when enabling analytics or adding new tracked events.
+
+---
+
+## Overview
+
+- **What’s used:** Google Analytics 4 (GA4) with the global site tag (`gtag.js`).
+- **Purpose:** Track traffic (page views) and how visitors interact with buttons and links.
+- **Behavior:** Analytics runs only when the environment variable `VITE_GA_MEASUREMENT_ID` is set. If it’s unset (e.g. local dev without `.env`), no GA script is loaded and all tracking calls are no-ops.
+
+---
+
+## Step 1: Get Your GA4 Measurement ID
+
+1. Go to [Google Analytics](https://analytics.google.com/).
+2. Create or select a **GA4 property** (not Universal Analytics).
+3. Add a **Web** data stream for your site (e.g. your homepage URL).
+4. Copy the **Measurement ID** (format: `G-XXXXXXXXXX`).
+
+You’ll use this ID in the steps below.
+
+---
+
+## Step 2: Local / Development
+
+1. In the **project root**, create a file named `.env` (it is gitignored).
+2. Add one line:
+   ```bash
+   VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX
+   ```
+   Replace `G-XXXXXXXXXX` with your actual Measurement ID.
+3. Restart the dev server (`npm run dev`) so Vite picks up the variable.
+4. Optional: Use `.env.example` as a template (it only documents the variable; copy to `.env` and fill in the value).
+
+Analytics will load in development when this variable is set. Leave `.env` missing or leave the variable empty to keep analytics off locally.
+
+---
+
+## Step 3: Production (e.g. GitHub Pages)
+
+To enable GA on the deployed site (built by GitHub Actions):
+
+1. In your GitHub repo go to **Settings** → **Secrets and variables** → **Actions**.
+2. Click **New repository secret**.
+3. Name: `VITE_GA_MEASUREMENT_ID`
+4. Value: your Measurement ID (e.g. `G-XXXXXXXXXX`).
+5. Save.
+
+The workflow in `.github/workflows/gh-pages.yml` already passes this secret into the build step:
+
+```yaml
+- name: Build
+  run: npm run build
+  env:
+    VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
+```
+
+After the next successful deploy, the live site will send data to GA4. If the secret is not set, the build still succeeds; GA simply won’t be included.
+
+---
+
+## Step 4: Verify in GA4
+
+1. In GA4, open **Reports** → **Realtime** and visit your site (with GA enabled). You should see an active user.
+2. Use **Reports** → **Engagement** → **Events** to see `page_view` and `click` (and any custom event names like `experience_tab`).
+3. Use **Explore** to build reports filtered by `event_label` or `link_location` to see which buttons/links are used most.
+
+Data can take a few minutes to appear in standard reports; Realtime is immediate.
+
+---
+
+## What Is Tracked Automatically
+
+### Page views
+
+- **When:** On first load of the site.
+- **Sent as:** GA4 default page view (path and title). Also triggered explicitly from `main.tsx` for the initial route.
+
+### Clicks (engagement events)
+
+All of these send a `click` event with `event_category: 'engagement'` and an `event_label` (and optional `link_url` / `link_location`) so you can see which CTAs are used.
+
+| Location   | Event label (examples)     | Notes                          |
+|-----------|----------------------------|---------------------------------|
+| Header    | `header_get_in_touch`      | “Get in Touch” → #contact       |
+| Header    | `header_resume_download`   | Resume download link           |
+| Header    | `header_linkedin`          | LinkedIn link                  |
+| Header    | `header_github`            | GitHub link                    |
+| Contact   | `contact_email`            | Email (mailto)                 |
+| Contact   | `contact_linkedin`        | LinkedIn card                  |
+| Contact   | `contact_github`           | GitHub card                    |
+| Footer    | `footer_linkedin`          | Footer LinkedIn                |
+| Footer    | `footer_github`            | Footer GitHub                  |
+| Footer    | `footer_facebook`          | Footer Facebook                |
+| Experience| `experience_tab`          | Tab switches (label: featured / all / enterprise) |
+| Patents   | `patents_google_patents`  | “Google Patents” link          |
+
+If a button or link has very few or no events, visitors may be skipping it or ad-blockers may be blocking the GA script (see “Limitations” below).
+
+---
+
+## Code Reference
+
+- **Utility:** `src/utils/analytics.ts`  
+  - `isAnalyticsEnabled()` – whether GA is configured.  
+  - `trackPageView(path, title?)` – send a page view.  
+  - `trackEvent(name, params?)` – send a custom event.  
+  - `trackClick(label, { url?, location? })` – send a click event with category “engagement”.
+- **GA script injection:** `vite.config.ts` – plugin `inject-google-analytics` injects the GA4 script into the built HTML only when `VITE_GA_MEASUREMENT_ID` is set at build time.
+- **Initial page view:** `src/main.tsx` calls `trackPageView(...)` after the app mounts.
+- **Components:** Header, Contact, Footer, Experience, and Patents call `trackClick` or `trackEvent` on relevant user actions.
+
+---
+
+## Adding New Tracked Actions
+
+1. **Link or button click:**  
+   In the component, add an `onClick` that calls:
+   ```ts
+   import { trackClick } from '../utils/analytics';
+   // ...
+   onClick={() => trackClick('unique_label', { location: 'section_name', url: optionalUrl })}
+   ```
+   Use a short, consistent `event_label` (e.g. `pricing_cta`, `nav_contact`).
+
+2. **Custom event (e.g. tab, filter):**  
+   Use `trackEvent` from `src/utils/analytics.ts`:
+   ```ts
+   trackEvent('event_name', { event_category: 'engagement', event_label: 'specific_action' });
+   ```
+
+3. **New section or page:**  
+   If you add client-side routing later, call `trackPageView(path, title)` when the route changes.
+
+After deploying, new events will show up in GA4 under **Engagement** → **Events** and in **Explore**.
+
+---
+
+## Limitations
+
+- **Ad blockers:** Many users block `googletagmanager.com`. For them, no page views or events are sent. You cannot measure “blocked” users with client-side GA alone.
+- **Privacy:** GA is subject to your privacy policy and any consent requirements (e.g. GDPR). Consider a cookie/consent banner if you need to comply with strict consent rules.
+- **Single-page app:** The site is a single page; we send one page view on load. If you add routing, call `trackPageView` on route changes so GA reflects each “page.”
+
+---
+
+## Quick Checklist
+
+- [ ] GA4 property created; Measurement ID copied (`G-XXXXXXXXXX`).
+- [ ] Local: `.env` with `VITE_GA_MEASUREMENT_ID=G-XXXXXXXXXX` (optional).
+- [ ] Production: GitHub secret `VITE_GA_MEASUREMENT_ID` set.
+- [ ] Workflow build step has `env.VITE_GA_MEASUREMENT_ID` (already in `gh-pages.yml`).
+- [ ] Deploy and verify in GA4 Realtime and Engagement → Events.
+
+For a short summary in the main README, see the **Google Analytics (optional)** section in [README.md](../README.md).

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,4 +1,5 @@
 import { ProfileData } from '../types';
+import { trackClick } from '../utils/analytics';
 
 interface ContactProps {
   profile: ProfileData;
@@ -14,21 +15,23 @@ export default function Contact({ profile }: ContactProps) {
         </p>
         
         <div className="grid md:grid-cols-3 gap-6 mb-12">
-          <a 
-            href={`mailto:${profile.email}`} 
+          <a
+            href={`mailto:${profile.email}`}
             className="bg-white/10 backdrop-blur-sm border border-white/20 p-6 rounded-xl hover:bg-white/20 transition"
+            onClick={() => trackClick('contact_email', { location: 'contact' })}
           >
             <div className="text-4xl mb-3">✉️</div>
             <h3 className="font-semibold mb-2">Email</h3>
             <p className="text-sm text-blue-100">{profile.email}</p>
           </a>
-          
+
           {profile.socials.linkedin && (
-            <a 
-              href={profile.socials.linkedin} 
-              target="_blank" 
-              rel="noopener noreferrer" 
+            <a
+              href={profile.socials.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
               className="bg-white/10 backdrop-blur-sm border border-white/20 p-6 rounded-xl hover:bg-white/20 transition"
+              onClick={() => trackClick('contact_linkedin', { url: profile.socials.linkedin!, location: 'contact' })}
             >
               <div className="text-4xl mb-3">💼</div>
               <h3 className="font-semibold mb-2">LinkedIn</h3>
@@ -42,13 +45,14 @@ export default function Contact({ profile }: ContactProps) {
               })()}</p>
             </a>
           )}
-          
+
           {profile.socials.github && (
-            <a 
-              href={profile.socials.github} 
-              target="_blank" 
-              rel="noopener noreferrer" 
+            <a
+              href={profile.socials.github}
+              target="_blank"
+              rel="noopener noreferrer"
               className="bg-white/10 backdrop-blur-sm border border-white/20 p-6 rounded-xl hover:bg-white/20 transition"
+              onClick={() => trackClick('contact_github', { url: profile.socials.github!, location: 'contact' })}
             >
               <div className="text-4xl mb-3">💻</div>
               <h3 className="font-semibold mb-2">GitHub</h3>

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Experience as ExperienceType } from '../types';
+import { trackEvent } from '../utils/analytics';
 
 interface ExperienceProps {
   experiences: ExperienceType[];
@@ -58,7 +59,10 @@ export default function Experience({ experiences }: ExperienceProps) {
         <div className="border-b border-gray-200 mb-8">
           <div className="flex flex-wrap gap-2">
             <button
-              onClick={() => setActiveTab('featured')}
+              onClick={() => {
+                setActiveTab('featured');
+                trackEvent('experience_tab', { event_label: 'featured', event_category: 'engagement' });
+              }}
               className={`px-6 py-3 font-medium text-sm border-b-2 transition ${
                 activeTab === 'featured'
                   ? 'border-black'
@@ -68,7 +72,10 @@ export default function Experience({ experiences }: ExperienceProps) {
               Featured Roles
             </button>
             <button
-              onClick={() => setActiveTab('all')}
+              onClick={() => {
+                setActiveTab('all');
+                trackEvent('experience_tab', { event_label: 'all', event_category: 'engagement' });
+              }}
               className={`px-6 py-3 font-medium text-sm border-b-2 transition ${
                 activeTab === 'all'
                   ? 'border-black'
@@ -78,7 +85,10 @@ export default function Experience({ experiences }: ExperienceProps) {
               All Experience
             </button>
             <button
-              onClick={() => setActiveTab('enterprise')}
+              onClick={() => {
+                setActiveTab('enterprise');
+                trackEvent('experience_tab', { event_label: 'enterprise', event_category: 'engagement' });
+              }}
               className={`px-6 py-3 font-medium text-sm border-b-2 transition ${
                 activeTab === 'enterprise'
                   ? 'border-black'

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { ProfileData } from '../types';
+import { trackClick } from '../utils/analytics';
 
 interface FooterProps {
   profile: ProfileData;
@@ -15,17 +16,17 @@ export default function Footer({ profile }: FooterProps) {
           <p className="text-sm">© {currentYear} {name}. All rights reserved.</p>
           <div className="flex gap-6 text-sm">
             {socials.linkedin && (
-              <a href={socials.linkedin} target="_blank" rel="noopener noreferrer" className="hover:text-white transition">
+              <a href={socials.linkedin} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('footer_linkedin', { url: socials.linkedin!, location: 'footer' })}>
                 LinkedIn
               </a>
             )}
             {socials.github && (
-              <a href={socials.github} target="_blank" rel="noopener noreferrer" className="hover:text-white transition">
+              <a href={socials.github} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('footer_github', { url: socials.github!, location: 'footer' })}>
                 GitHub
               </a>
             )}
             {socials.facebook && (
-              <a href={socials.facebook} target="_blank" rel="noopener noreferrer" className="hover:text-white transition">
+              <a href={socials.facebook} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('footer_facebook', { url: socials.facebook!, location: 'footer' })}>
                 Facebook
               </a>
             )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { ProfileData } from '../types';
 import { resolveYearsPlaceholder, resolveHeadlineStatValue } from '../utils/profile';
+import { trackClick } from '../utils/analytics';
 
 interface HeaderProps {
   profile: ProfileData;
@@ -39,23 +40,40 @@ export default function Header({ profile }: HeaderProps) {
             </div>
           )}
           <div className="flex flex-wrap gap-4">
-            <a href="#contact" className="px-6 py-3 bg-black text-white rounded-lg hover:bg-gray-800 transition font-medium">
+            <a
+              href="#contact"
+              className="px-6 py-3 bg-black text-white rounded-lg hover:bg-gray-800 transition font-medium"
+              onClick={() => trackClick('header_get_in_touch', { location: 'header' })}
+            >
               Get in Touch
             </a>
-            <a 
-              href={profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf'} 
-              download 
+            <a
+              href={profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf'}
+              download
               className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium inline-flex items-center gap-2"
+              onClick={() => trackClick('header_resume_download', { url: profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf', location: 'header' })}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
               </svg>
               Resume
             </a>
-            <a href={profile.socials.linkedin} target="_blank" rel="noopener noreferrer" className="px-6 py-3 border border-gray-300 rounded-lg hover:border-gray-900 transition font-medium">
+            <a
+              href={profile.socials.linkedin}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-6 py-3 border border-gray-300 rounded-lg hover:border-gray-900 transition font-medium"
+              onClick={() => trackClick('header_linkedin', { url: profile.socials.linkedin, location: 'header' })}
+            >
               LinkedIn
             </a>
-            <a href={profile.socials.github} target="_blank" rel="noopener noreferrer" className="px-6 py-3 border border-gray-300 rounded-lg hover:border-gray-900 transition font-medium">
+            <a
+              href={profile.socials.github}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="px-6 py-3 border border-gray-300 rounded-lg hover:border-gray-900 transition font-medium"
+              onClick={() => trackClick('header_github', { url: profile.socials.github, location: 'header' })}
+            >
               GitHub
             </a>
           </div>

--- a/src/components/Patents.tsx
+++ b/src/components/Patents.tsx
@@ -1,4 +1,5 @@
 import { PatentsData } from '../types';
+import { trackClick } from '../utils/analytics';
 
 interface PatentsProps {
   data: PatentsData;
@@ -85,11 +86,12 @@ export default function Patents({ data }: PatentsProps) {
           <div className="mt-6 text-center">
             <p className="text-sm text-gray-500">
               Patent details available on{" "}
-              <a 
+              <a
                 href={patents[0]?.url ?? (patents[0]?.patentSlug ? `${googlePatentsBaseUrl}${patents[0].patentSlug}/` : 'https://patents.google.com/')}
-                target="_blank" 
+                target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 hover:text-blue-800 font-medium underline"
+                onClick={() => trackClick('patents_google_patents', { location: 'patents', url: patents[0]?.url ?? (patents[0]?.patentSlug ? `${googlePatentsBaseUrl}${patents[0].patentSlug}/` : 'https://patents.google.com/') })}
               >
                 Google Patents
               </a>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,13 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { trackPageView } from './utils/analytics'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
   </StrictMode>,
 )
+
+// Track initial page view (single-page site)
+trackPageView(window.location.pathname || '/', document.title)

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -1,0 +1,60 @@
+/**
+ * Google Analytics (GA4) utility.
+ * - Tracks page views and custom events (clicks, outbound links, etc.).
+ * - No-op when VITE_GA_MEASUREMENT_ID is unset (dev/local builds).
+ */
+
+declare global {
+  interface Window {
+    gtag?: (
+      command: 'config' | 'event' | 'js',
+      targetId: string,
+      params?: Record<string, unknown>
+    ) => void;
+    dataLayer?: unknown[];
+  }
+}
+
+const MEASUREMENT_ID = import.meta.env.VITE_GA_MEASUREMENT_ID as string | undefined;
+
+export function isAnalyticsEnabled(): boolean {
+  return Boolean(typeof window !== 'undefined' && MEASUREMENT_ID);
+}
+
+/** Send a page view (call after route/section change if you add routing later). */
+export function trackPageView(path: string, title?: string): void {
+  if (!isAnalyticsEnabled() || !window.gtag) return;
+  window.gtag('config', MEASUREMENT_ID!, {
+    page_path: path,
+    page_title: title ?? document.title,
+  });
+}
+
+/** Track a custom event (e.g. button_click, link_click). */
+export function trackEvent(
+  eventName: string,
+  params?: {
+    event_category?: string;
+    event_label?: string;
+    link_url?: string;
+    link_text?: string;
+    link_location?: string;
+    [key: string]: string | number | boolean | undefined;
+  }
+): void {
+  if (!isAnalyticsEnabled() || !window.gtag) return;
+  window.gtag('event', eventName, params as Record<string, unknown>);
+}
+
+/** Convenience: track CTA/link click (so you can see which buttons/links get used or "blocked" via absence of events). */
+export function trackClick(
+  label: string,
+  options?: { url?: string; location?: string }
+): void {
+  trackEvent('click', {
+    event_category: 'engagement',
+    event_label: label,
+    link_url: options?.url,
+    link_location: options?.location,
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
+    "types": ["vite/client"],
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",


### PR DESCRIPTION
## Summary
Adds Google Analytics 4 to the profile site so traffic and key interactions (button/link clicks) can be tracked.

## Changes
- **GA4 integration:** `src/utils/analytics.ts` for page views and custom events; Vite plugin injects gtag script when `VITE_GA_MEASUREMENT_ID` is set.
- **Event tracking:** Clicks on Get in Touch, Resume, LinkedIn, GitHub, Email, Contact/Footer links, Experience tabs, and Patents link send `click` events with labels for GA4 reporting.
- **Config:** `.env.example` documents the env var; `tsconfig.json` includes `vite/client` for `import.meta.env`; GitHub Actions build step uses `VITE_GA_MEASUREMENT_ID` secret.
- **Docs:** `docs/GOOGLE_ANALYTICS.md` with setup steps, what is tracked, and how to add new events; README section links to it.

## How to enable
1. Create a GA4 property and copy Measurement ID (`G-XXXXXXXXXX`).
2. **Local:** add `VITE_GA_MEASUREMENT_ID=G-...` to `.env`.
3. **Production:** add repo secret `VITE_GA_MEASUREMENT_ID` in Settings → Secrets. Next deploy will include GA.

Analytics is a no-op when the variable is unset (e.g. dev without `.env`).