### PR TITLE
Add GA4 resume_download event to track resume link clicks

### DIFF
--- a/docs/GOOGLE_ANALYTICS.md
+++ b/docs/GOOGLE_ANALYTICS.md
@@ -69,6 +69,16 @@ After the next successful deploy, the live site will send data to GA4. If the se
 
 Data can take a few minutes to appear in standard reports; Realtime is immediate.
 
+### How to see resume downloads
+
+Each time someone clicks the Resume button we send a dedicated event **`resume_download`**. To see how many people have (clicked to) download your resume:
+
+1. In GA4 go to **Reports** → **Engagement** → **Events**.
+2. Find the event **`resume_download`** in the table. The **Event count** is the number of times the resume link was clicked (which in most setups leads to a download).
+3. Optional: In **Explore**, create a report with **Event name** = `resume_download` to see trends over time or by date.
+
+Note: We track the *click* on the Resume link. Browsers may open the PDF in a new tab instead of downloading; in both cases the event is sent. Users with ad blockers may not be counted.
+
 ---
 
 ## What Is Tracked Automatically
@@ -85,7 +95,7 @@ All of these send a `click` event with `event_category: 'engagement'` and an `ev
 | Location   | Event label (examples)     | Notes                          |
 |-----------|----------------------------|---------------------------------|
 | Header    | `header_get_in_touch`      | “Get in Touch” → #contact       |
-| Header    | `header_resume_download`   | Resume download link           |
+| Header    | `header_resume_download`   | Resume link (also sends `resume_download` event) |
 | Header    | `header_linkedin`          | LinkedIn link                  |
 | Header    | `header_github`            | GitHub link                    |
 | Contact   | `contact_email`            | Email (mailto)                 |
@@ -107,7 +117,8 @@ If a button or link has very few or no events, visitors may be skipping it or ad
   - `isAnalyticsEnabled()` – whether GA is configured.  
   - `trackPageView(path, title?)` – send a page view.  
   - `trackEvent(name, params?)` – send a custom event.  
-  - `trackClick(label, { url?, location? })` – send a click event with category “engagement”.
+  - `trackClick(label, { url?, location? })` – send a click event with category “engagement”.  
+  - `trackResumeDownload(url?)` – send a `resume_download` event (used for the Resume button).
 - **GA script injection:** `vite.config.ts` – plugin `inject-google-analytics` injects the GA4 script into the built HTML only when `VITE_GA_MEASUREMENT_ID` is set at build time.
 - **Initial page view:** `src/main.tsx` calls `trackPageView(...)` after the app mounts.
 - **Components:** Header, Contact, Footer, Experience, and Patents call `trackClick` or `trackEvent` on relevant user actions.

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { ProfileData } from '../types';
 import { resolveYearsPlaceholder, resolveHeadlineStatValue } from '../utils/profile';
-import { trackClick } from '../utils/analytics';
+import { trackClick, trackResumeDownload } from '../utils/analytics';
 
 interface HeaderProps {
   profile: ProfileData;
@@ -51,7 +51,10 @@ export default function Header({ profile }: HeaderProps) {
               href={profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf'}
               download
               className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium inline-flex items-center gap-2"
-              onClick={() => trackClick('header_resume_download', { url: profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf', location: 'header' })}
+              onClick={() => {
+                trackClick('header_resume_download', { url: profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf', location: 'header' });
+                trackResumeDownload(profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf');
+              }}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -58,3 +58,12 @@ export function trackClick(
     link_location: options?.location,
   });
 }
+
+/** Track resume download. Use this when the user clicks the resume link so you can see "resume_download" in GA4. */
+export function trackResumeDownload(url?: string): void {
+  trackEvent('resume_download', {
+    event_category: 'engagement',
+    event_label: 'resume',
+    link_url: url,
+  });
+}


### PR DESCRIPTION
## Summary
Makes it easy to see how many users click the Resume link by sending a dedicated GA4 event `resume_download` in addition to the existing `click` event.

## Changes
- **`src/utils/analytics.ts`:** Add `trackResumeDownload(url?)` that sends a `resume_download` event.
- **Header:** Resume button now calls `trackResumeDownload()` on click so GA4 shows a distinct "resume_download" event.
- **docs/GOOGLE_ANALYTICS.md:** Add "How to see resume downloads" (Reports → Engagement → Events → `resume_download`) and update code reference.

## How to use in GA4
Reports → Engagement → Events → find **`resume_download`**. Event count = number of resume link clicks (proxy for downloads).