### PR TITLE
Add scroll depth, section-view tracking, distinct GA event names, and analytics coverage doc

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import Header from './components/Header';
 import Philosophy from './components/Philosophy';
 import Experience from './components/Experience';
@@ -28,8 +29,14 @@ import {
   EarlyInitiativesData,
   Education as EducationType,
 } from './types';
+import { initScrollDepthTracking, initSectionViewTracking } from './utils/analytics';
 
 function App() {
+  useEffect(() => {
+    initScrollDepthTracking();
+    initSectionViewTracking();
+  }, []);
+
   return (
     <div className="min-h-screen bg-white">
       <Header profile={profileData as ProfileData} />

--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -8,7 +8,7 @@ export default function Achievements({ data }: AchievementsProps) {
   const { sectionTitle, sectionSubtitle, achievements } = data;
 
   return (
-    <section className="py-20 px-6 bg-gray-50">
+    <section data-analytics-section="achievements" className="py-20 px-6 bg-gray-50">
       <div className="container mx-auto max-w-6xl">
         <h2 className="text-4xl font-semibold mb-4">{sectionTitle}</h2>
         <p className="text-gray-600 mb-12">{sectionSubtitle}</p>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -7,7 +7,7 @@ interface ContactProps {
 
 export default function Contact({ profile }: ContactProps) {
   return (
-    <section id="contact" className="py-20 px-6 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
+    <section id="contact" data-analytics-section="contact" className="py-20 px-6 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
       <div className="container mx-auto max-w-4xl text-center">
         <h2 className="text-4xl font-semibold mb-6">{profile.contactTitle ?? "Let's Connect"}</h2>
         <p className="text-xl mb-8 text-blue-50">
@@ -18,7 +18,7 @@ export default function Contact({ profile }: ContactProps) {
           <a
             href={`mailto:${profile.email}`}
             className="bg-white/10 backdrop-blur-sm border border-white/20 p-6 rounded-xl hover:bg-white/20 transition"
-            onClick={() => trackClick('contact_email', { location: 'contact' })}
+            onClick={() => trackClick('email_click', { location: 'contact' })}
           >
             <div className="text-4xl mb-3">✉️</div>
             <h3 className="font-semibold mb-2">Email</h3>
@@ -31,7 +31,7 @@ export default function Contact({ profile }: ContactProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="bg-white/10 backdrop-blur-sm border border-white/20 p-6 rounded-xl hover:bg-white/20 transition"
-              onClick={() => trackClick('contact_linkedin', { url: profile.socials.linkedin!, location: 'contact' })}
+              onClick={() => trackClick('linkedin_click', { url: profile.socials.linkedin!, location: 'contact' })}
             >
               <div className="text-4xl mb-3">💼</div>
               <h3 className="font-semibold mb-2">LinkedIn</h3>
@@ -52,7 +52,7 @@ export default function Contact({ profile }: ContactProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="bg-white/10 backdrop-blur-sm border border-white/20 p-6 rounded-xl hover:bg-white/20 transition"
-              onClick={() => trackClick('contact_github', { url: profile.socials.github!, location: 'contact' })}
+              onClick={() => trackClick('github_click', { url: profile.socials.github!, location: 'contact' })}
             >
               <div className="text-4xl mb-3">💻</div>
               <h3 className="font-semibold mb-2">GitHub</h3>

--- a/src/components/EarlyInitiatives.tsx
+++ b/src/components/EarlyInitiatives.tsx
@@ -8,7 +8,7 @@ export default function EarlyInitiatives({ data }: EarlyInitiativesProps) {
   const { sectionTitle, sectionSubtitle, learningJourneyText, initiatives } = data;
 
   return (
-    <section className="py-16 px-6 bg-gray-50">
+    <section data-analytics-section="early_initiatives" className="py-16 px-6 bg-gray-50">
       <div className="container mx-auto max-w-6xl">
         <div className="mb-8">
           <h2 className="text-3xl font-semibold mb-2">{sectionTitle}</h2>

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -6,7 +6,7 @@ interface EducationProps {
 
 export default function Education({ items }: EducationProps) {
   return (
-    <section className="py-20 px-6 bg-gray-50">
+    <section data-analytics-section="education" className="py-20 px-6 bg-gray-50">
       <div className="container mx-auto max-w-6xl">
         <h2 className="text-4xl font-semibold mb-12">Education</h2>
         

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -51,7 +51,7 @@ export default function Experience({ experiences }: ExperienceProps) {
   const isCurrentRole = (range: string) => range.includes('Present');
 
   return (
-    <section className="py-20 px-6">
+    <section data-analytics-section="experience" className="py-20 px-6">
       <div className="container mx-auto max-w-6xl">
         <h2 className="text-4xl font-semibold mb-12">Professional Experience</h2>
         

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,23 +10,23 @@ export default function Footer({ profile }: FooterProps) {
   const { name, socials } = profile;
 
   return (
-    <footer className="py-12 px-6 bg-gray-900 text-gray-400">
+    <footer data-analytics-section="footer" className="py-12 px-6 bg-gray-900 text-gray-400">
       <div className="container mx-auto max-w-6xl">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
           <p className="text-sm">© {currentYear} {name}. All rights reserved.</p>
           <div className="flex gap-6 text-sm">
             {socials.linkedin && (
-              <a href={socials.linkedin} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('footer_linkedin', { url: socials.linkedin!, location: 'footer' })}>
+              <a href={socials.linkedin} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('linkedin_click', { url: socials.linkedin!, location: 'footer' })}>
                 LinkedIn
               </a>
             )}
             {socials.github && (
-              <a href={socials.github} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('footer_github', { url: socials.github!, location: 'footer' })}>
+              <a href={socials.github} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('github_click', { url: socials.github!, location: 'footer' })}>
                 GitHub
               </a>
             )}
             {socials.facebook && (
-              <a href={socials.facebook} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('footer_facebook', { url: socials.facebook!, location: 'footer' })}>
+              <a href={socials.facebook} target="_blank" rel="noopener noreferrer" className="hover:text-white transition" onClick={() => trackClick('facebook_click', { url: socials.facebook!, location: 'footer' })}>
                 Facebook
               </a>
             )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,7 +43,7 @@ export default function Header({ profile }: HeaderProps) {
             <a
               href="#contact"
               className="px-6 py-3 bg-black text-white rounded-lg hover:bg-gray-800 transition font-medium"
-              onClick={() => trackClick('header_get_in_touch', { location: 'header' })}
+              onClick={() => trackClick('get_in_touch', { location: 'header' })}
             >
               Get in Touch
             </a>
@@ -51,10 +51,7 @@ export default function Header({ profile }: HeaderProps) {
               href={profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf'}
               download
               className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition font-medium inline-flex items-center gap-2"
-              onClick={() => {
-                trackClick('header_resume_download', { url: profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf', location: 'header' });
-                trackResumeDownload(profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf');
-              }}
+              onClick={() => trackResumeDownload(profile.resumeUrl ?? '/Sumeet_Sahu_Resume.pdf')}
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
@@ -66,7 +63,7 @@ export default function Header({ profile }: HeaderProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="px-6 py-3 border border-gray-300 rounded-lg hover:border-gray-900 transition font-medium"
-              onClick={() => trackClick('header_linkedin', { url: profile.socials.linkedin, location: 'header' })}
+              onClick={() => trackClick('linkedin_click', { url: profile.socials.linkedin, location: 'header' })}
             >
               LinkedIn
             </a>
@@ -75,7 +72,7 @@ export default function Header({ profile }: HeaderProps) {
               target="_blank"
               rel="noopener noreferrer"
               className="px-6 py-3 border border-gray-300 rounded-lg hover:border-gray-900 transition font-medium"
-              onClick={() => trackClick('header_github', { url: profile.socials.github, location: 'header' })}
+              onClick={() => trackClick('github_click', { url: profile.socials.github, location: 'header' })}
             >
               GitHub
             </a>

--- a/src/components/Patents.tsx
+++ b/src/components/Patents.tsx
@@ -9,7 +9,7 @@ export default function Patents({ data }: PatentsProps) {
   const { sectionTitle, sectionSubtitle, googlePatentsBaseUrl = 'https://patents.google.com/patent/', patents } = data;
 
   return (
-    <section className="py-20 px-6 bg-white">
+    <section data-analytics-section="patents" className="py-20 px-6 bg-white">
       <div className="container mx-auto max-w-6xl">
         <div className="mb-8">
           <h2 className="text-3xl font-semibold mb-2">{sectionTitle}</h2>
@@ -91,7 +91,7 @@ export default function Patents({ data }: PatentsProps) {
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-blue-600 hover:text-blue-800 font-medium underline"
-                onClick={() => trackClick('patents_google_patents', { location: 'patents', url: patents[0]?.url ?? (patents[0]?.patentSlug ? `${googlePatentsBaseUrl}${patents[0].patentSlug}/` : 'https://patents.google.com/') })}
+                onClick={() => trackClick('patents_link', { location: 'patents', url: patents[0]?.url ?? (patents[0]?.patentSlug ? `${googlePatentsBaseUrl}${patents[0].patentSlug}/` : 'https://patents.google.com/') })}
               >
                 Google Patents
               </a>

--- a/src/components/Philosophy.tsx
+++ b/src/components/Philosophy.tsx
@@ -6,7 +6,7 @@ interface PhilosophyProps {
 
 export default function Philosophy({ data }: PhilosophyProps) {
   return (
-    <section className="py-20 px-6 bg-gradient-to-r from-gray-900 to-gray-800 text-white">
+    <section data-analytics-section="philosophy" className="py-20 px-6 bg-gradient-to-r from-gray-900 to-gray-800 text-white">
       <div className="container mx-auto max-w-4xl text-center">
         <p className="text-3xl md:text-4xl font-light leading-relaxed mb-6 italic">
           "{data.quote}"

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -6,7 +6,7 @@ interface SkillsProps {
 
 export default function Skills({ skills }: SkillsProps) {
   return (
-    <section className="py-20 px-6 bg-gray-50">
+    <section data-analytics-section="skills" className="py-20 px-6 bg-gray-50">
       <div className="container mx-auto max-w-6xl">
         <h2 className="text-4xl font-semibold mb-12">Skills & Expertise</h2>
         


### PR DESCRIPTION
## Summary
Extends GA4 tracking with scroll depth and section visibility, switches CTA events to distinct names, and documents full analytics coverage.

## Changes

### Distinct event names
- CTA/link events now use their own event names in GA4 (e.g. `get_in_touch`, `linkedin_click`, `github_click`, `email_click`, `facebook_click`, `patents_link`) instead of a single `click` with labels.
- Resume uses only `trackResumeDownload()` (sends `resume_download`). `trackClick(eventName, options)` now sends `eventName` as the GA event.

### Scroll depth
- `scroll_depth` event fired when user first reaches 25%, 50%, 75%, and 100% of the page.
- `initScrollDepthTracking(thresholds?)` in `analytics.ts`; called from `App.tsx` on mount.

### Section visibility
- `section_view` event fired the first time each section is ~20% visible (IntersectionObserver).
- Sections: philosophy, experience, achievements, patents, early_initiatives, education, skills, contact, footer (via `data-analytics-section` on each).
- `initSectionViewTracking()` in `analytics.ts`; called from `App.tsx` on mount.

### Docs
- **GOOGLE_ANALYTICS.md:** “How to see scroll depth” and “How to see which sections were viewed”; events table updated; new “Analytics coverage” section (what’s implemented, what GA4 provides, what’s not implemented). Code reference updated for new helpers.