### PR TITLE
refactor: data-driven experience cards, analytics cleanup, tests, and SEO

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,16 +12,19 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Type check
+        run: npm run type-check
 
       - name: Install Chromium dependencies (for resume PDF)
         run: |
@@ -37,7 +40,7 @@ jobs:
           VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
 
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "puppeteer": "^23.6.0",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
-        "vite": "^6.4.1"
+        "vite": "^6.4.1",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1774,6 +1775,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2097,6 +2116,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2316,6 +2450,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ast-types": {
@@ -2633,6 +2777,16 @@
         "node": "*"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -2714,6 +2868,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2729,6 +2900,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chromium-bidi": {
@@ -2933,6 +3114,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3212,6 +3403,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3655,6 +3853,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3673,6 +3881,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/extract-zip": {
@@ -5151,6 +5369,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5532,6 +5757,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -6121,6 +6363,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -6182,6 +6431,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -6348,6 +6611,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6439,6 +6722,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6454,6 +6751,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -6742,6 +7069,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6845,6 +7268,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,12 +7,14 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "generate-resume": "node resume-generator/generator.js"
+    "generate-resume": "node resume-generator/generator.js",
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "author": "Sumeet Sahu",
   "license": "MIT",
   "devDependencies": {
-    "puppeteer": "^23.6.0",
     "@tailwindcss/postcss": "^4.1.18",
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
@@ -24,9 +26,11 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "postcss": "^8.5.6",
+    "puppeteer": "^23.6.0",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
-    "vite": "^6.4.1"
+    "vite": "^6.4.1",
+    "vitest": "^3.2.4"
   },
   "dependencies": {
     "react": "^19.2.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,8 +33,12 @@ import { initScrollDepthTracking, initSectionViewTracking } from './utils/analyt
 
 function App() {
   useEffect(() => {
-    initScrollDepthTracking();
-    initSectionViewTracking();
+    const cleanupScroll = initScrollDepthTracking();
+    const cleanupSections = initSectionViewTracking();
+    return () => {
+      cleanupScroll();
+      cleanupSections();
+    };
   }, []);
 
   return (

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -6,6 +6,71 @@ interface ExperienceProps {
   experiences: ExperienceType[];
 }
 
+// ---------------------------------------------------------------------------
+// Color scheme definitions — all class strings are literal so Tailwind's
+// JIT scanner picks them up during build. Do NOT construct dynamically.
+// ---------------------------------------------------------------------------
+interface ColorScheme {
+  gradient: string;
+  tag: string;
+  dot: string;
+  badge: string;
+  metricValues: [string, string, string];
+}
+
+const COLOR_SCHEME_MAP: Record<string, ColorScheme> = {
+  green: {
+    gradient: 'bg-gradient-to-r from-green-50 to-blue-50 border border-green-100',
+    tag: 'bg-green-50 text-green-700',
+    dot: 'bg-green-400',
+    badge: 'bg-green-600 text-white',
+    metricValues: ['text-green-600', 'text-blue-600', 'text-teal-600'],
+  },
+  orange: {
+    gradient: 'bg-gradient-to-r from-orange-50 to-yellow-50 border border-orange-100',
+    tag: 'bg-orange-50 text-orange-700',
+    dot: 'bg-orange-400',
+    badge: 'bg-orange-600 text-white',
+    metricValues: ['text-orange-600', 'text-yellow-600', 'text-amber-600'],
+  },
+  red: {
+    gradient: 'bg-gradient-to-r from-red-50 to-pink-50 border border-red-100',
+    tag: 'bg-red-50 text-red-700',
+    dot: 'bg-red-400',
+    badge: 'bg-red-600 text-white',
+    metricValues: ['text-red-600', 'text-pink-600', 'text-rose-600'],
+  },
+  blue: {
+    gradient: 'bg-gradient-to-r from-blue-50 to-indigo-50 border border-blue-100',
+    tag: 'bg-blue-50 text-blue-700',
+    dot: 'bg-blue-400',
+    badge: 'bg-blue-600 text-white',
+    metricValues: ['text-blue-600', 'text-indigo-600', 'text-sky-600'],
+  },
+  purple: {
+    gradient: 'bg-gradient-to-r from-purple-50 to-indigo-50 border border-purple-100',
+    tag: 'bg-purple-50 text-purple-700',
+    dot: 'bg-purple-400',
+    badge: 'bg-purple-600 text-white',
+    metricValues: ['text-purple-600', 'text-indigo-600', 'text-violet-600'],
+  },
+  gray: {
+    gradient: 'bg-white border border-gray-200',
+    tag: 'bg-gray-50 text-gray-700',
+    dot: 'bg-gray-400',
+    badge: 'bg-gray-600 text-white',
+    metricValues: ['text-gray-700', 'text-gray-600', 'text-gray-500'],
+  },
+};
+
+const DEFAULT_COLOR_SCHEME = COLOR_SCHEME_MAP.gray;
+
+function getColorScheme(exp: ExperienceType): ColorScheme {
+  return COLOR_SCHEME_MAP[exp.colorScheme ?? ''] ?? DEFAULT_COLOR_SCHEME;
+}
+
+const isCurrentRole = (range: string) => range.includes('Present');
+
 export default function Experience({ experiences }: ExperienceProps) {
   const [activeTab, setActiveTab] = useState('featured');
 
@@ -15,50 +80,20 @@ export default function Experience({ experiences }: ExperienceProps) {
     return getYear(b.range) - getYear(a.range);
   });
 
-  // Featured experiences - manually select the most impactful roles
-  const featuredExperiences = [
-    sortedExperiences.find(exp => exp.company.includes('Intuit')),
-    sortedExperiences.find(exp => exp.company.includes('Amazon')),
-    sortedExperiences.find(exp => exp.company.includes('myPNRstatus')),
-  ].filter(Boolean) as ExperienceType[];
-
-  // Enterprise companies (all experiences since myPNRstatus is now featured separately)
-  const enterpriseExperiences = sortedExperiences;
-
-  const getCompanyGradient = (company: string) => {
-    if (company.includes('Intuit')) {
-      return 'bg-gradient-to-r from-green-50 to-blue-50 border border-green-100';
-    } else if (company.includes('Amazon')) {
-      return 'bg-gradient-to-r from-orange-50 to-yellow-50 border border-orange-100';
-    } else if (company.includes('Adobe')) {
-      return 'bg-gradient-to-r from-red-50 to-pink-50 border border-red-100';
-    } else if (company.includes('myPNRstatus')) {
-      return 'bg-gradient-to-r from-purple-50 to-indigo-50 border border-purple-100';
-    }
-    return 'bg-white border border-gray-200';
-  };
-
-  const getTechTagColor = (company: string) => {
-    if (company.includes('Intuit')) return 'bg-green-50 text-green-700';
-    if (company.includes('Amazon')) return 'bg-orange-50 text-orange-700';
-    if (company.includes('Adobe')) return 'bg-red-50 text-red-700';
-    if (company.includes('Microsoft')) return 'bg-blue-50 text-blue-700';
-    if (company.includes('myPNRstatus')) return 'bg-purple-50 text-purple-700';
-    if (company.includes('CA Technology')) return 'bg-gray-50 text-gray-700';
-    return 'bg-gray-100 text-gray-700';
-  };
-
-  const isCurrentRole = (range: string) => range.includes('Present');
+  // Featured experiences — driven by the `featured` flag in data
+  const featuredExperiences = sortedExperiences.filter((exp) => exp.featured);
 
   return (
     <section data-analytics-section="experience" className="py-20 px-6">
       <div className="container mx-auto max-w-6xl">
         <h2 className="text-4xl font-semibold mb-12">Professional Experience</h2>
-        
+
         {/* Tab Navigation */}
         <div className="border-b border-gray-200 mb-8">
           <div className="flex flex-wrap gap-2">
             <button
+              aria-selected={activeTab === 'featured'}
+              role="tab"
               onClick={() => {
                 setActiveTab('featured');
                 trackEvent('experience_tab', { event_label: 'featured', event_category: 'engagement' });
@@ -72,6 +107,8 @@ export default function Experience({ experiences }: ExperienceProps) {
               Featured Roles
             </button>
             <button
+              aria-selected={activeTab === 'all'}
+              role="tab"
               onClick={() => {
                 setActiveTab('all');
                 trackEvent('experience_tab', { event_label: 'all', event_category: 'engagement' });
@@ -85,6 +122,8 @@ export default function Experience({ experiences }: ExperienceProps) {
               All Experience
             </button>
             <button
+              aria-selected={activeTab === 'enterprise'}
+              role="tab"
               onClick={() => {
                 setActiveTab('enterprise');
                 trackEvent('experience_tab', { event_label: 'enterprise', event_category: 'engagement' });
@@ -95,7 +134,7 @@ export default function Experience({ experiences }: ExperienceProps) {
                   : 'border-transparent hover:border-gray-300 text-gray-600'
               }`}
             >
-              Enterprise ({enterpriseExperiences.length})
+              Enterprise ({sortedExperiences.length})
             </button>
           </div>
         </div>
@@ -103,166 +142,111 @@ export default function Experience({ experiences }: ExperienceProps) {
         {/* Featured Tab */}
         {activeTab === 'featured' && (
           <div className="space-y-8">
-            {featuredExperiences.map((exp, index) => (
-              <div key={index} className={`p-8 rounded-xl ${getCompanyGradient(exp.company)}`}>
-                <div className="flex items-center gap-2 mb-3">
-                  <h3 className="text-3xl font-semibold">{exp.company}</h3>
-                  {isCurrentRole(exp.range) && (
-                    <span className="px-3 py-1 bg-green-600 text-white text-xs rounded-full font-medium">
-                      Current
-                    </span>
-                  )}
-                  {exp.company.includes('myPNRstatus') && (
-                    <span className="px-3 py-1 bg-orange-600 text-white text-xs rounded-full font-medium">
-                      Founder
-                    </span>
+            {featuredExperiences.length === 0 && (
+              <p className="text-gray-500">No featured experiences configured.</p>
+            )}
+            {featuredExperiences.map((exp, index) => {
+              const cs = getColorScheme(exp);
+              return (
+                <div key={index} className={`p-8 rounded-xl ${cs.gradient}`}>
+                  <div className="flex items-center gap-2 mb-3">
+                    <h3 className="text-3xl font-semibold">{exp.company}</h3>
+                    {isCurrentRole(exp.range) && (
+                      <span className="px-3 py-1 bg-green-600 text-white text-xs rounded-full font-medium">
+                        Current
+                      </span>
+                    )}
+                    {exp.badge && (
+                      <span className={`px-3 py-1 ${cs.badge} text-xs rounded-full font-medium`}>
+                        {exp.badge}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xl text-gray-700 mb-2">{exp.role}</p>
+                  <p className="text-sm text-gray-600 mb-4">{exp.range}</p>
+                  <p className="text-gray-700 leading-relaxed mb-6">{exp.summary}</p>
+
+                  {/* Key metrics */}
+                  {exp.metrics && exp.metrics.length > 0 && (
+                    <div
+                      className={`${
+                        exp.metrics.length <= 2 ? 'grid grid-cols-2' : 'grid md:grid-cols-3'
+                      } gap-4 text-center mb-6`}
+                    >
+                      {exp.metrics.map((metric, i) => (
+                        <div key={i} className="bg-white p-4 rounded-lg">
+                          <p className={`text-2xl font-bold ${cs.metricValues[i % cs.metricValues.length]}`}>
+                            {metric.value}
+                          </p>
+                          <p className="text-xs text-gray-600">{metric.label}</p>
+                        </div>
+                      ))}
+                    </div>
                   )}
                 </div>
-                <p className="text-xl text-gray-700 mb-2">{exp.role}</p>
-                <p className="text-sm text-gray-600 mb-4">{exp.range}</p>
-                <p className="text-gray-700 leading-relaxed mb-6">{exp.summary}</p>
-                
-                {/* Show metrics for Intuit, Amazon and myPNRstatus */}
-                {exp.company.includes('Intuit') && (
-                  <div className="grid md:grid-cols-3 gap-4 text-center mb-6">
-                    <div className="bg-white p-4 rounded-lg">
-                      <p className="text-2xl font-bold text-green-600">8,000+</p>
-                      <p className="text-xs text-gray-600">Developers Impacted</p>
-                    </div>
-                    <div className="bg-white p-4 rounded-lg">
-                      <p className="text-2xl font-bold text-blue-600">50%</p>
-                      <p className="text-xs text-gray-600">Productivity Boost</p>
-                    </div>
-                    <div className="bg-white p-4 rounded-lg">
-                      <p className="text-2xl font-bold text-teal-600">1 Year</p>
-                      <p className="text-xs text-gray-600">Time to Impact</p>
-                    </div>
-                  </div>
-                )}
-
-                {exp.company.includes('Amazon') && (
-                  <div className="grid md:grid-cols-3 gap-4 text-center mb-6">
-                    <div className="bg-white p-4 rounded-lg">
-                      <p className="text-2xl font-bold text-orange-600">$600K</p>
-                      <p className="text-xs text-gray-600">Annual Savings</p>
-                    </div>
-                    <div className="bg-white p-4 rounded-lg">
-                      <p className="text-2xl font-bold text-yellow-600">1.5B</p>
-                      <p className="text-xs text-gray-600">Transactions/Day</p>
-                    </div>
-                    <div className="bg-white p-4 rounded-lg">
-                      <p className="text-2xl font-bold text-amber-600">30</p>
-                      <p className="text-xs text-gray-600">Team Size</p>
-                    </div>
-                  </div>
-                )}
-
-                {exp.company.includes('myPNRstatus') && (
-                  <div className="grid grid-cols-2 gap-4 mb-6">
-                    <div className="bg-white p-4 rounded-lg text-center">
-                      <p className="text-3xl font-bold text-purple-600">600K</p>
-                      <p className="text-xs text-gray-600">Unique Users</p>
-                    </div>
-                    <div className="bg-white p-4 rounded-lg text-center">
-                      <p className="text-3xl font-bold text-indigo-600">6</p>
-                      <p className="text-xs text-gray-600">Years Active</p>
-                    </div>
-                  </div>
-                )}
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 
         {/* All Experience Tab */}
         {activeTab === 'all' && (
           <div className="space-y-8">
-            {sortedExperiences.map((exp, index) => (
-              <div key={index} className="grid md:grid-cols-4 gap-6 pb-8 border-b last:border-0">
-                <div>
-                  <p className="text-sm text-gray-500">{exp.range}</p>
-                </div>
-                <div className="md:col-span-3">
-                  <div className="flex items-center gap-2 mb-2">
-                    <h3 className="text-2xl font-semibold">{exp.company}</h3>
-                    {isCurrentRole(exp.range) && (
-                      <span className="px-2 py-1 bg-green-100 text-green-700 text-xs rounded font-medium">
-                        Current
-                      </span>
-                    )}
+            {sortedExperiences.map((exp, index) => {
+              const cs = getColorScheme(exp);
+              return (
+                <div key={index} className="grid md:grid-cols-4 gap-6 pb-8 border-b last:border-0">
+                  <div>
+                    <p className="text-sm text-gray-500">{exp.range}</p>
                   </div>
-                  <p className="text-lg text-gray-600 mb-3">{exp.role}</p>
-                  
-                  {/* Hierarchical roles for consolidated experiences */}
-                  {exp.roles && exp.roles.length > 0 ? (
-                    <div className="mb-4">
-                      <p className="text-gray-700 leading-relaxed mb-4">{exp.summary}</p>
-                      <div className="ml-4 border-l-2 border-gray-300 pl-6 space-y-6">
-                        {exp.roles.map((role, roleIndex) => (
-                          <div key={roleIndex} className="relative">
-                            <div className="absolute -left-[26px] w-3 h-3 rounded-full bg-red-400 border-2 border-white"></div>
-                            <div className="mb-2">
-                              <p className="font-semibold text-gray-800">{role.title}</p>
-                              <p className="text-sm text-gray-500">{role.range}</p>
+                  <div className="md:col-span-3">
+                    <div className="flex items-center gap-2 mb-2">
+                      <h3 className="text-2xl font-semibold">{exp.company}</h3>
+                      {isCurrentRole(exp.range) && (
+                        <span className="px-2 py-1 bg-green-100 text-green-700 text-xs rounded font-medium">
+                          Current
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-lg text-gray-600 mb-3">{exp.role}</p>
+
+                    {/* Hierarchical roles for consolidated experiences */}
+                    {exp.roles && exp.roles.length > 0 ? (
+                      <div className="mb-4">
+                        <p className="text-gray-700 leading-relaxed mb-4">{exp.summary}</p>
+                        <div className="ml-4 border-l-2 border-gray-300 pl-6 space-y-6">
+                          {exp.roles.map((role, roleIndex) => (
+                            <div key={roleIndex} className="relative">
+                              <div
+                                className={`absolute -left-[26px] w-3 h-3 rounded-full ${cs.dot} border-2 border-white`}
+                              ></div>
+                              <div className="mb-2">
+                                <p className="font-semibold text-gray-800">{role.title}</p>
+                                <p className="text-sm text-gray-500">{role.range}</p>
+                              </div>
+                              <p className="text-sm text-gray-700 leading-relaxed">{role.summary}</p>
                             </div>
-                            <p className="text-sm text-gray-700 leading-relaxed">{role.summary}</p>
-                          </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="text-gray-700 leading-relaxed mb-4">{exp.summary}</p>
+                    )}
+
+                    {/* Technology tags */}
+                    {exp.tags && exp.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-2">
+                        {exp.tags.map((tag, tagIndex) => (
+                          <span key={tagIndex} className={`px-3 py-1 rounded text-xs ${cs.tag}`}>
+                            {tag}
+                          </span>
                         ))}
                       </div>
-                    </div>
-                  ) : (
-                    <p className="text-gray-700 leading-relaxed mb-4">{exp.summary}</p>
-                  )}
-                  
-                  <div className="flex flex-wrap gap-2">
-                    {exp.company.includes('Intuit') && (
-                      <>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>GenAI</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Claude/ChatGPT</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Python</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Automation</span>
-                      </>
-                    )}
-                    {exp.company.includes('Amazon') && (
-                      <>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Java</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Apache Beam</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>AWS</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Distributed Systems</span>
-                      </>
-                    )}
-                    {exp.company.includes('Adobe') && (
-                      <>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Java</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Docker</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Azure</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Microservices</span>
-                      </>
-                    )}
-                    {exp.company.includes('Microsoft') && (
-                      <>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>C#</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>ASP.NET</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Bing</span>
-                      </>
-                    )}
-                    {exp.company.includes('myPNRstatus') && (
-                      <>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>PHP</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>MySQL</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>SMS Gateway</span>
-                      </>
-                    )}
-                    {exp.company.includes('CA Technology') && (
-                      <>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>EITM</span>
-                        <span className={`px-3 py-1 rounded text-xs ${getTechTagColor(exp.company)}`}>Service Desk</span>
-                      </>
                     )}
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         )}
 
@@ -271,40 +255,44 @@ export default function Experience({ experiences }: ExperienceProps) {
           <>
             <p className="text-sm text-gray-500 mb-8">Large-scale technology companies and entrepreneurial ventures</p>
             <div className="grid md:grid-cols-2 gap-6">
-              {enterpriseExperiences.map((exp, index) => (
-                <div
-                  key={index}
-                  className={`p-6 rounded-xl hover:shadow-lg transition ${
-                    isCurrentRole(exp.range) ? 'bg-blue-50 border border-blue-200' : 'border border-gray-200'
-                  }`}
-                >
-                  <div className="flex items-center gap-2 mb-2">
-                    <h3 className="text-xl font-semibold">{exp.company}</h3>
-                    {isCurrentRole(exp.range) && (
-                      <span className="px-2 py-1 bg-green-600 text-white text-xs rounded">Current</span>
-                    )}
-                    {exp.company.includes('myPNRstatus') && (
-                      <span className="px-2 py-1 bg-purple-600 text-white text-xs rounded">Founder</span>
+              {sortedExperiences.map((exp, index) => {
+                const cs = getColorScheme(exp);
+                return (
+                  <div
+                    key={index}
+                    className={`p-6 rounded-xl hover:shadow-lg transition ${
+                      isCurrentRole(exp.range) ? 'bg-blue-50 border border-blue-200' : 'border border-gray-200'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2 mb-2">
+                      <h3 className="text-xl font-semibold">{exp.company}</h3>
+                      {isCurrentRole(exp.range) && (
+                        <span className="px-2 py-1 bg-green-600 text-white text-xs rounded">Current</span>
+                      )}
+                      {exp.badge && (
+                        <span className={`px-2 py-1 ${cs.badge} text-xs rounded`}>{exp.badge}</span>
+                      )}
+                    </div>
+                    <p className="text-sm text-gray-500 mb-3">{exp.range}</p>
+                    <p className="text-sm text-gray-700 mb-2">{exp.role}</p>
+
+                    {/* Show role progression for consolidated experiences */}
+                    {exp.roles && exp.roles.length > 0 && (
+                      <div className="mt-3 pt-3 border-t border-gray-200">
+                        <p className="text-xs text-gray-500 mb-2">Career Progression:</p>
+                        <div className="space-y-1">
+                          {exp.roles.map((role, roleIndex) => (
+                            <div key={roleIndex} className="text-xs text-gray-600">
+                              <span className="font-medium">•</span> {role.title}{' '}
+                              <span className="text-gray-400">({role.range})</span>
+                            </div>
+                          ))}
+                        </div>
+                      </div>
                     )}
                   </div>
-                  <p className="text-sm text-gray-500 mb-3">{exp.range}</p>
-                  <p className="text-sm text-gray-700 mb-2">{exp.role}</p>
-                  
-                  {/* Show role progression for consolidated experiences */}
-                  {exp.roles && exp.roles.length > 0 && (
-                    <div className="mt-3 pt-3 border-t border-gray-200">
-                      <p className="text-xs text-gray-500 mb-2">Career Progression:</p>
-                      <div className="space-y-1">
-                        {exp.roles.map((role, roleIndex) => (
-                          <div key={roleIndex} className="text-xs text-gray-600">
-                            <span className="font-medium">•</span> {role.title} <span className="text-gray-400">({role.range})</span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              ))}
+                );
+              })}
             </div>
           </>
         )}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -9,8 +9,9 @@ export default function Skills({ skills }: SkillsProps) {
     <section data-analytics-section="skills" className="py-20 px-6 bg-gray-50">
       <div className="container mx-auto max-w-6xl">
         <h2 className="text-4xl font-semibold mb-12">Skills & Expertise</h2>
-        
-        <div className="grid md:grid-cols-4 gap-6">
+
+        {/* Responsive grid: 1 col on mobile → 2 on small → 4 on desktop */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
           {skills.map((group, index) => (
             <div
               key={index}
@@ -28,7 +29,18 @@ export default function Skills({ skills }: SkillsProps) {
                   } else {
                     return (
                       <p key={skillIndex} className="text-sm text-gray-600">
-                        {skill.name}
+                        {skill.link ? (
+                          <a
+                            href={skill.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-blue-600 hover:underline transition-colors"
+                          >
+                            {skill.name}
+                          </a>
+                        ) : (
+                          skill.name
+                        )}
                       </p>
                     );
                   }

--- a/src/data/experience.json
+++ b/src/data/experience.json
@@ -3,19 +3,38 @@
         "role": "Principal Engineer",
         "company": "Intuit - Bangalore",
         "summary": "Pioneered transformative GenAI-driven code generation initiative for 8,000+ developers, fundamentally re-engineering the software development lifecycle. Architected and deployed cutting-edge AI solutions and automated workflows, achieving 50% productivity boost and drastically reducing time-to-market. Lead specialized team in exploring high-impact GenAI tools, fostering innovation and cross-functional excellence that has redefined developer efficiency at scale.",
-        "range": "September 2024 — Present"
+        "range": "September 2024 — Present",
+        "colorScheme": "green",
+        "featured": true,
+        "tags": ["GenAI", "Claude/ChatGPT", "Python", "Automation"],
+        "metrics": [
+            { "value": "8,000+", "label": "Developers Impacted" },
+            { "value": "50%", "label": "Productivity Boost" },
+            { "value": "1 Year", "label": "Time to Impact" }
+        ]
     },
     {
         "role": "Senior Software Development Engineer",
         "company": "Amazon India - Bangalore",
         "summary": "Led team of 30 SDEs developing MAARS, a mission-critical financial system for manifest ingestion, contractual accounting, and multi-billion-dollar reconciliation for Amazon Transportation. Spearheaded architectural redesign of Allocation System using Apache Beam, processing 1.5 billion daily transactions at 15,000 TPS. Migration reduced processing costs by 60%, delivering $600K in annual savings. Drove expansion of Amazon Global Mile business unit and launched ship-cost improvement platform providing actionable cost-reduction insights for leadership.",
-        "range": "February 2020 — September 2024"
+        "range": "February 2020 — September 2024",
+        "colorScheme": "orange",
+        "featured": true,
+        "tags": ["Java", "Apache Beam", "AWS", "Distributed Systems"],
+        "metrics": [
+            { "value": "$600K", "label": "Annual Savings" },
+            { "value": "1.5B", "label": "Transactions/Day" },
+            { "value": "30", "label": "Team Size" }
+        ]
     },
     {
         "role": "Computer Scientist - II (promoted from Computer Scientist)",
         "company": "Adobe India - Noida",
         "summary": "Progressive career spanning platform architecture and SDK development at Adobe. Led Gyarados platform for Adobe Experience Cloud serving millions; developed PDF Scan SDK with DRM, security, and compliance. Specialized in multi-cloud containerization, orchestration, and enterprise-grade document solutions.",
         "range": "July 2015 — February 2020",
+        "colorScheme": "red",
+        "featured": false,
+        "tags": ["Java", "Docker", "Azure", "Microservices"],
         "roles": [
             {
                 "title": "Computer Scientist - II",
@@ -33,18 +52,32 @@
         "role": "Software Engineer 2",
         "company": "Microsoft India - Hyderabad",
         "summary": "Architected and delivered end-to-end feature areas for Bing UX, serving as technical lead for major segment-wide initiatives from concept to deployment. Collaborated closely with design and product management to champion user experience, translating complex requirements into high-performance code and scalable technical designs. Subject matter expert navigating intricate technical challenges and driving engineering excellence across the segment, ensuring seamless and responsive interface for millions of users.",
-        "range": "December 2012 — June 2015"
+        "range": "December 2012 — June 2015",
+        "colorScheme": "blue",
+        "featured": false,
+        "tags": ["C#", "ASP.NET", "Bing"]
     },
     {
         "role": "Founder and Developer",
         "company": "myPNRstatus",
         "summary": "Founded and scaled myPNRstatus, innovative startup and automated SMS alert service streamlining travel experience for Indian Railway passengers. Engineered system delivering real-time updates on PNR status and train delays, eliminating manual tracking. As solo founder, grew platform to 600,000 unique users through organic adoption, demonstrating ability to build and manage high-traffic, user-centric products from ground up.",
-        "range": "November 2010 — November 2016"
+        "range": "November 2010 — November 2016",
+        "colorScheme": "purple",
+        "featured": true,
+        "badge": "Founder",
+        "tags": ["PHP", "MySQL", "SMS Gateway"],
+        "metrics": [
+            { "value": "600K", "label": "Unique Users" },
+            { "value": "6", "label": "Years Active" }
+        ]
     },
     {
         "role": "Software Engineer",
         "company": "CA Technology - Hyderabad",
         "summary": "Worked on EITM Software Service Desk providing Single Point of Contact (SPOC) to meet communications needs of both Users and IT, satisfying Customer and IT Provider objectives.",
-        "range": "June 2007 — December 2012"
+        "range": "June 2007 — December 2012",
+        "colorScheme": "gray",
+        "featured": false,
+        "tags": ["EITM", "Service Desk"]
     }
 ]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,12 +4,27 @@ export interface Role {
   summary: string;
 }
 
+export interface ExperienceMetric {
+  value: string;
+  label: string;
+}
+
 export interface Experience {
   role: string;
   company: string;
   summary: string;
   range: string;
   roles?: Role[]; // Optional: for consolidated experiences with career progression
+  /** Color scheme key (green | orange | red | blue | purple | gray) — drives gradients, tag colors, and metric colors */
+  colorScheme?: string;
+  /** Whether this experience appears in the Featured Roles tab */
+  featured?: boolean;
+  /** Optional badge label shown as a pill (e.g. "Founder") */
+  badge?: string;
+  /** Technology tags shown in the All Experience tab */
+  tags?: string[];
+  /** Key metrics shown in the Featured Roles card */
+  metrics?: ExperienceMetric[];
 }
 
 export interface Skill {

--- a/src/utils/profile.test.ts
+++ b/src/utils/profile.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  getYearsOfExperience,
+  resolveYearsPlaceholder,
+  resolveHeadlineStatValue,
+} from './profile';
+
+// ---------------------------------------------------------------------------
+// getYearsOfExperience
+// ---------------------------------------------------------------------------
+describe('getYearsOfExperience', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns 0 for an empty string', () => {
+    expect(getYearsOfExperience('')).toBe(0);
+  });
+
+  it('returns 0 for a non-date string', () => {
+    expect(getYearsOfExperience('not-a-date')).toBe(0);
+  });
+
+  it('computes full years correctly using month precision', () => {
+    // Mock today as 1 Sep 2025 → 18 full years since June 2007
+    vi.setSystemTime(new Date('2025-09-01'));
+    expect(getYearsOfExperience('2007-06')).toBe(18);
+  });
+
+  it('does not count a partial year', () => {
+    // Mock today as 1 Jan 2025 → still 17 full years since June 2007
+    vi.setSystemTime(new Date('2025-01-01'));
+    expect(getYearsOfExperience('2007-06')).toBe(17);
+  });
+
+  it('handles a date with only a year (defaults to January)', () => {
+    // '2020' → Jan 2020; mock today 15 Jun 2027 → 7 full years
+    vi.setSystemTime(new Date('2027-06-15'));
+    expect(getYearsOfExperience('2020')).toBe(7);
+  });
+
+  it('returns 0 when less than one full year has passed', () => {
+    vi.setSystemTime(new Date('2024-03-01'));
+    expect(getYearsOfExperience('2024-01')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveYearsPlaceholder
+// ---------------------------------------------------------------------------
+describe('resolveYearsPlaceholder', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-09-01'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns original text when careerStartDate is undefined', () => {
+    expect(resolveYearsPlaceholder('Hello {{years}}', undefined)).toBe('Hello {{years}}');
+  });
+
+  it('returns original text when no placeholder is present', () => {
+    expect(resolveYearsPlaceholder('Hello world', '2007-06')).toBe('Hello world');
+  });
+
+  it('replaces {{years}} with the computed year count', () => {
+    expect(resolveYearsPlaceholder('{{years}}+ years of experience', '2007-06')).toBe(
+      '18+ years of experience'
+    );
+  });
+
+  it('replaces all occurrences of {{years}}', () => {
+    expect(resolveYearsPlaceholder('{{years}} years ({{years}}+)', '2007-06')).toBe('18 years (18+)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveHeadlineStatValue
+// ---------------------------------------------------------------------------
+describe('resolveHeadlineStatValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-09-01'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns value unchanged when careerStartDate is undefined', () => {
+    expect(resolveHeadlineStatValue('{{years}}+', undefined)).toBe('{{years}}+');
+  });
+
+  it('replaces {{years}}+ with computed value', () => {
+    expect(resolveHeadlineStatValue('{{years}}+', '2007-06')).toBe('18+');
+  });
+
+  it('replaces {{years}} inline in a string', () => {
+    expect(resolveHeadlineStatValue('{{years}} Years', '2007-06')).toBe('18 Years');
+  });
+
+  it('returns a plain value unchanged', () => {
+    expect(resolveHeadlineStatValue('8K+', '2007-06')).toBe('8K+');
+  });
+
+  it('returns $600K+ unchanged', () => {
+    expect(resolveHeadlineStatValue('$600K+', '2007-06')).toBe('$600K+');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,8 +2,36 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'node:path'
 import fs from 'node:fs'
+// Reuse the shared year-calculation utility (no browser APIs — safe in Node context)
+import { getYearsOfExperience } from './src/utils/profile'
 
-// Injects profile.json into index.html placeholders at build time
+// ---------------------------------------------------------------------------
+// HTML escape helper — used for attribute values and inline script content
+// ---------------------------------------------------------------------------
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+// ---------------------------------------------------------------------------
+// Safely serialize an object for <script type="application/ld+json">.
+// Escapes characters that could confuse HTML parsers (<, >, &, /).
+// ---------------------------------------------------------------------------
+function safeJsonLd(obj: unknown): string {
+  return JSON.stringify(obj, null, 2)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\//g, '\\u002f')
+}
+
+// ---------------------------------------------------------------------------
+// Injects profile.json into index.html placeholders at build time.
+// Also adds Open Graph, Twitter Card meta tags, and JSON-LD Person schema.
+// ---------------------------------------------------------------------------
 function injectProfileHtml(): import('vite').Plugin {
   return {
     name: 'inject-profile-html',
@@ -14,44 +42,71 @@ function injectProfileHtml(): import('vite').Plugin {
         const profilePath = path.join(root, 'src', 'data', 'profile.json')
         if (!fs.existsSync(profilePath)) return html
         const profile = JSON.parse(fs.readFileSync(profilePath, 'utf8'))
+
         const title = `${profile.name} - ${profile.title}`
         const author = profile.name
         const years = profile.careerStartDate
           ? getYearsOfExperience(profile.careerStartDate)
           : null
-        const rawMeta =
-          profile.metaDescription ?? profile.summary ?? ''
+        const rawMeta = profile.metaDescription ?? profile.summary ?? ''
         const metaDescription =
           years !== null && rawMeta.includes('{{years}}')
             ? rawMeta.replace(/\{\{years\}\}/g, String(years))
             : rawMeta
-        return html
+        const website = profile.website ?? ''
+
+        // Replace existing placeholders
+        let result = html
           .replace(/\{\{SITE_TITLE\}\}/g, escapeHtml(title))
           .replace(/\{\{SITE_AUTHOR\}\}/g, escapeHtml(author))
           .replace(/\{\{SITE_META_DESCRIPTION\}\}/g, escapeHtml(metaDescription))
+
+        // Inject Open Graph + Twitter Card meta tags before </head>
+        const ogTags = [
+          `<meta property="og:type" content="website" />`,
+          `<meta property="og:title" content="${escapeHtml(title)}" />`,
+          `<meta property="og:description" content="${escapeHtml(metaDescription)}" />`,
+          `<meta property="og:url" content="${escapeHtml(website)}" />`,
+          `<meta property="og:site_name" content="${escapeHtml(profile.name)}" />`,
+          `<meta name="twitter:card" content="summary" />`,
+          `<meta name="twitter:title" content="${escapeHtml(title)}" />`,
+          `<meta name="twitter:description" content="${escapeHtml(metaDescription)}" />`,
+        ].join('\n    ')
+
+        // Inject JSON-LD Person schema
+        const sameAs: string[] = Object.values(profile.socials ?? {}).filter(Boolean) as string[]
+        const jsonLdObject = {
+          '@context': 'https://schema.org',
+          '@type': 'Person',
+          name: profile.name,
+          jobTitle: profile.title,
+          description: metaDescription,
+          url: website,
+          ...(profile.email ? { email: profile.email } : {}),
+          ...(sameAs.length > 0 ? { sameAs } : {}),
+          ...(profile.location
+            ? {
+                address: {
+                  '@type': 'PostalAddress',
+                  addressLocality: profile.location,
+                },
+              }
+            : {}),
+        }
+        const jsonLdScript = `<script type="application/ld+json">\n    ${safeJsonLd(jsonLdObject)}\n    </script>`
+
+        return result.replace(
+          '</head>',
+          `    ${ogTags}\n    ${jsonLdScript}\n  </head>`
+        )
       },
     },
   }
 }
 
-function getYearsOfExperience(careerStartDate: string): number {
-  const [y, m] = careerStartDate.split('-').map(Number)
-  if (!y || Number.isNaN(y)) return 0
-  const start = new Date(y, (m ?? 1) - 1, 1)
-  const now = new Date()
-  const years = (now.getTime() - start.getTime()) / (365.25 * 24 * 60 * 60 * 1000)
-  return Math.floor(years)
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-}
-
+// ---------------------------------------------------------------------------
 // Injects Google Analytics (GA4) when VITE_GA_MEASUREMENT_ID is set
+// ---------------------------------------------------------------------------
 function injectGoogleAnalytics(): import('vite').Plugin {
   return {
     name: 'inject-google-analytics',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

- **Data-driven Experience component** — replaced all `company.includes()` hardcoding with a `COLOR_SCHEME_MAP` + new `colorScheme`, `featured`, `badge`, `tags`, and `metrics` fields in `experience.json`. Changing featured roles or colors is now a JSON edit, not a code change.
- **Skill links rendered** — `skill.link` in `skills.json` now renders as `<a>` anchors (Docker, AWS, Azure, Apache Beam were silently ignored before).
- **Analytics listener cleanup** — `initScrollDepthTracking` and `initSectionViewTracking` now return cleanup functions; `App.tsx` calls them in `useEffect` return to prevent scroll listener accumulation on remount.
- **Duplicate year logic removed** — `vite.config.ts` now imports `getYearsOfExperience` from `src/utils/profile` instead of duplicating it.
- **Vitest added** — 15 unit tests for `profile.ts` utilities with fake timers; `npm test`, `npm run test:watch`, and `npm run type-check` scripts added.
- **CI modernised** — Node.js 18 (EOL) → 22 LTS; all GitHub Actions bumped to latest (`checkout@v4`, `setup-node@v4`, `actions-gh-pages@v4`); added type-check step before build.
- **OG + Twitter Card meta tags** — injected at build time via Vite plugin (`og:type`, `og:title`, `og:description`, `og:url`, `og:site_name`, `twitter:card`, `twitter:title`, `twitter:description`).
- **JSON-LD Person schema** — `<script type="application/ld+json">` injected into `<head>` at build time with name, jobTitle, description, URL, email, sameAs, and address.
- **Skills grid responsive** — `md:grid-cols-4` → `grid-cols-1 sm:grid-cols-2 lg:grid-cols-4` (was broken on tablets).

## Test plan

- [x] `npm run type-check` — passes with zero errors
- [x] `npm test` — 15/15 tests pass
- [x] `npm run build` — clean build, OG + JSON-LD tags verified in `dist/index.html`
- [ ] Visually verify Experience tabs (Featured / All / Enterprise) render identically to before
- [ ] Confirm skill links open correct URLs in new tab
- [ ] Check Skills section on a tablet viewport (~768px) shows 2-column grid
